### PR TITLE
Sort projects list by creation date (desc)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,10 +28,10 @@
       <h2>Projects</h2>
       <ul>
         <li><a href="projects/free_carry_map.html">Free-Carry Map</a></li>
-        <li><a href="projects/nyc-explorer/">NYC Explorer</a></li>
-        <li><a href="projects/fire_withdrawal-tiers.html">FIRE Withdrawal Rate Tiers</a></li>
         <li><a href="projects/zrh-explorer/">ZRH Explorer</a></li>
+        <li><a href="projects/nyc-explorer/">NYC Explorer</a></li>
         <li><a href="projects/training-tracker.html">Training Tracker</a></li>
+        <li><a href="projects/fire_withdrawal-tiers.html">FIRE Withdrawal Rate Tiers</a></li>
         <li><a href="projects/montecarlo_portfolio_simulation.html">Monte Carlo Portfolio Simulation</a></li>
       </ul>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -27,12 +27,12 @@
       </ul>
       <h2>Projects</h2>
       <ul>
+        <li><a href="projects/free_carry_map.html">Free-Carry Map</a></li>
         <li><a href="projects/nyc-explorer/">NYC Explorer</a></li>
+        <li><a href="projects/fire_withdrawal-tiers.html">FIRE Withdrawal Rate Tiers</a></li>
         <li><a href="projects/zrh-explorer/">ZRH Explorer</a></li>
         <li><a href="projects/training-tracker.html">Training Tracker</a></li>
-        <li><a href="projects/fire_withdrawal-tiers.html">FIRE Withdrawal Rate Tiers</a></li>
         <li><a href="projects/montecarlo_portfolio_simulation.html">Monte Carlo Portfolio Simulation</a></li>
-        <li><a href="projects/free_carry_map.html">Free-Carry Map</a></li>
       </ul>
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- Reordered the Projects list on the main page (`public/index.html`) so entries are sorted by creation date, newest first, based on each project's earliest git commit.
- Order: Free-Carry Map (2026-06-19) → ZRH Explorer (2026-05-25) → NYC Explorer (2026-05-23) → Training Tracker (2026-05-11) → FIRE Withdrawal Rate Tiers (2026-05-11) → Monte Carlo Portfolio Simulation (2026-05-05).

## Test plan
- [x] Verified creation dates via `git log`/`git show` for each project's introducing commit.
- [x] Visual diff of `public/index.html` confirms only the `<li>` order changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VBffHz9xnAYtWrriNiAmYF)_